### PR TITLE
Adjust the order of task groups in an OKR.

### DIFF
--- a/templates/errata/slides.md
+++ b/templates/errata/slides.md
@@ -20,8 +20,8 @@
 * **Update**: (*{{epic.status_update.updated.split('T')[0]}}*) {{epic.status_update.cleaned}}{% if attribution %} — *{{epic.status_update.author}}*{% endif %}{% endif %}
 
 {.column}
-{% for category in by_epic[key] | sort %}
-**{{ category }}**:
+{% for category in by_epic[key] | sort(reverse = True) %}
+{{ category }}:
 {% for issue in by_epic[key][category] %}
 * ([{{ issue.key }}]({{ server }}/browse/{{ issue.key }}))
   {{ issue['summary'].replace('[', '').replace(']', ':') }}{% endfor %}


### PR DESCRIPTION
The default order is alphabetic: done, in progress, to do. This patch
did a reverse on the order, so the new order will be like this:
To do, in progress, done.

This patch also did a tiny adjustment of font style, cancelled the bold
style for the task groups (to do, in progress, to do) to help make the
whole slide more reasonable.